### PR TITLE
remove g++ build dependency to allow cross-build

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Evgeny Boger <boger@contactless.ru>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 9), pkg-config, g++, libjsoncpp-dev, libmosquittopp-dev, libmosquitto-dev, libwbmqtt-dev (>= 1.3.3)
+Build-Depends: debhelper (>= 9), pkg-config, libjsoncpp-dev, libmosquittopp-dev, libmosquitto-dev, libwbmqtt-dev (>= 1.3.3)
 
 Package: wb-homa-gpio
 Architecture: any


### PR DESCRIPTION
as per https://www.debian.org/doc/manuals/maint-guide/dreq.ru.html,
"Some packages like gcc and make which are required by the build-essential package are implied"