### PR TITLE
Verbose error message.

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -89,7 +89,8 @@ namespace
         if (itLine != chipConfig->Lines.end()) {
             wb_throw(TGpioDriverException,
                      "duplicate GPIO offset in config: '" + to_string(line.Offset) + "' at chip '" +
-                         chipConfig->Path + "'");
+                     chipConfig->Path + "' defined as '" + line.Name + 
+                     "'. It is already defined as '" + itLine->Name + "'. To override set similar MQTT id (name).");
         }
 
         chipConfig->Lines.push_back(line);

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-gpio (2.0.8) unstable; urgency=medium
+
+  * verbose error message for duplicate GPIO offset in config is added
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 31 Nov 2020 18:57:00 +0500
+
 wb-mqtt-gpio (2.0.7) unstable; urgency=medium
 
   * move system config to /var/lib/wb-mqtt-gpio/conf.d folder


### PR DESCRIPTION
Verbose error message for duplicate GPIO offset in config is added.