### PR TITLE
Wrong inpulse counting with enabled inverted option is fixed

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-mqtt-gpio (2.1.2) unstable; urgency=medium
 
-  * Wrong inpulse counting with enabled inverted option is fixed
+  * Wrong impulse counting with enabled inverted option is fixed
 
  -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Sun, 23 May 2021 11:39:00 +0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-gpio (2.1.2) unstable; urgency=medium
+
+  * Wrong inpulse counting with enabled inverted option is fixed
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Sun, 23 May 2021 11:39:00 +0500
+
 wb-mqtt-gpio (2.1.1) stable; urgency=medium
 
   * fix typo in error message

--- a/gpio_line.h
+++ b/gpio_line.h
@@ -21,6 +21,8 @@ class TGpioLine
 
     TValue<uint8_t> Value;
 
+    std::chrono::microseconds GetIntervalFromPreviousInterrupt(const TTimePoint & interruptTimePoint) const;
+
 public:
     TGpioLine(const PGpioChip & chip, const TGpioLineConfig & config);
 


### PR DESCRIPTION
На ядре 4.9.22-wb1:
- при установке GPIOHANDLE_REQUEST_ACTIVE_LOW приходят не все события;
- установка чего-то отличного от GPIOEVENT_REQUEST_BOTH_EDGES не даёт результата, ядро всё равно шлёт события от фронта и спада.
На ядре 5.10.0-wb1:
- установка чего-то отличного от GPIOEVENT_REQUEST_BOTH_EDGES приводит к тому, что ядро всё равно шлёт события от фронта и спада, но маркирует их как фронт или спад, т.е. отличить нельзя.

В результате фильтрую события в wb-mqtt-gpio.