### PR TITLE
Slow interrupt handling is fixed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,18 +17,19 @@ LDFLAGS= -ljsoncpp -lwbmqtt1 -lpthread
 
 GPIO_BIN=wb-mqtt-gpio
 
-GPIO_SOURCES= 			\
-  gpio_driver.cpp		\
-  gpio_chip_driver.cpp	\
-  gpio_chip.cpp 		\
-  gpio_line.cpp 		\
-  gpio_counter.cpp		\
-  utils.cpp 			\
-  types.cpp 			\
-  log.cpp 				\
-  exceptions.cpp		\
-  config.cpp			\
-  file_utils.cpp		\
+GPIO_SOURCES=              \
+  gpio_driver.cpp          \
+  gpio_chip_driver.cpp     \
+  gpio_chip.cpp            \
+  gpio_line.cpp            \
+  gpio_counter.cpp         \
+  utils.cpp                \
+  types.cpp                \
+  log.cpp                  \
+  exceptions.cpp           \
+  config.cpp               \
+  file_utils.cpp           \
+  interruption_context.cpp \
 
 GPIO_OBJECTS=$(GPIO_SOURCES:.cpp=.o)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-gpio (2.1.3) unstable; urgency=medium
+
+  * Slow interrupt handling is fixed.
+    The bug was introduced in Linux kernel v5.7-rc1 because of switch to monotonic clock as a source of interrupt timestamps
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Wed, 02 Jun 2021 13:22:00 +0500
+
 wb-mqtt-gpio (2.1.2) unstable; urgency=medium
 
   * Wrong impulse counting with enabled inverted option is fixed

--- a/gpio_chip_driver.cpp
+++ b/gpio_chip_driver.cpp
@@ -219,7 +219,7 @@ bool TGpioChipDriver::HandleInterrupt(const TInterruptionContext & ctx)
                 }
 
                 auto edge = data.id == GPIOEVENT_EVENT_RISING_EDGE ? EGpioEdge::RISING : EGpioEdge::FALLING;
-                auto time = ctx.ToSteadyClock(chrono::system_clock::time_point(chrono::nanoseconds(data.timestamp)));
+                auto time = ctx.ToSteadyClock(data.timestamp);
 
                 if (line->HandleInterrupt(edge, time) != EInterruptStatus::DEBOUNCE) {   // update value
                     gpiohandle_data data;
@@ -405,7 +405,6 @@ void TGpioChipDriver::PollLinesValues(const TGpioLines & lines)
     }
 
     auto now = chrono::steady_clock::now();
-
     for (uint32_t i = 0; i < lines.size(); ++i) {
         const auto & line = lines[i];
         assert(line->GetFd() == fd);

--- a/interruption_context.cpp
+++ b/interruption_context.cpp
@@ -1,0 +1,23 @@
+#include "interruption_context.h"
+
+bool TInterruptionContext::InterruptTimestampClockIsMonotonic = false;
+
+TInterruptionContext::TInterruptionContext(int count, struct epoll_event * events)
+    : Count(count)
+    , Events(events)
+    , Diff(std::chrono::nanoseconds::zero())
+{
+    if (!InterruptTimestampClockIsMonotonic) {
+        Diff = std::chrono::nanoseconds(std::chrono::steady_clock::now().time_since_epoch() - std::chrono::system_clock::now().time_since_epoch());
+    }
+}
+
+std::chrono::steady_clock::time_point TInterruptionContext::ToSteadyClock(__u64 timestamp) const
+{
+    return std::chrono::steady_clock::time_point(std::chrono::nanoseconds(timestamp) + Diff);
+}
+
+void TInterruptionContext::SetMonotonicClockForInterruptTimestamp()
+{
+    InterruptTimestampClockIsMonotonic = true;
+}

--- a/interruption_context.h
+++ b/interruption_context.h
@@ -1,24 +1,21 @@
 #pragma once
 
 #include <chrono>
+#include <linux/types.h>
 
 struct TInterruptionContext
 {
+    static bool InterruptTimestampClockIsMonotonic;
+
     const int                      Count;
     const struct epoll_event *     Events;
-    const std::chrono::nanoseconds Diff;
+    std::chrono::nanoseconds       Diff;
 
-    TInterruptionContext(int count, struct epoll_event * events)
-        : Count(count)
-        , Events(events)
-        , Diff(std::chrono::steady_clock::now().time_since_epoch() - std::chrono::system_clock::now().time_since_epoch())
-    {}
-
+    TInterruptionContext(int count, struct epoll_event * events);
     TInterruptionContext(const TInterruptionContext &) = delete;
     TInterruptionContext(TInterruptionContext &&) = delete;
 
-    inline std::chrono::steady_clock::time_point ToSteadyClock(const std::chrono::system_clock::time_point & systemTime) const
-    {
-        return std::chrono::steady_clock::time_point(systemTime.time_since_epoch() + Diff);
-    }
+    std::chrono::steady_clock::time_point ToSteadyClock(__u64 timestamp) const;
+
+    static void SetMonotonicClockForInterruptTimestamp();
 };


### PR DESCRIPTION
The bug was introduced in Linux kernel v5.7-rc1 because of switch to monotonic clock as a source of interrupt timestamps