### PR TITLE
Feature/on topic handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ DEBUG_CFLAGS=-Wall -ggdb -rdynamic -std=c++14 -O0 -I.
 RELEASE_CFLAGS=-Wall -DNDEBUG -std=c++14 -Os -I.
 TESTING_CFLAGS=-Wall -std=c++14 -Os -I.	# release with asserts
 CFLAGS=$(if $(DEBUG), $(DEBUG_CFLAGS), $(if $(TESTING), $(TESTING_CFLAGS), $(RELEASE_CFLAGS)))
-LDFLAGS= -ljsoncpp -lwbmqtt1 -lpthread
+LDFLAGS= -lwbmqtt1 -lpthread
 
 GPIO_BIN=wb-mqtt-gpio
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-gpio (2.3.0) unstable; urgency=medium
+
+  * libwbmqtt1-2 2.1.0 support
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 08 Jun 2021 12:29:00 +0500
+
 wb-mqtt-gpio (2.2.0) unstable; urgency=medium
 
   * It is recommended to use linux kernel v5.3-rc3 or newer because of a bug in events from GPIO with active low setting.

--- a/debian/control
+++ b/debian/control
@@ -3,11 +3,11 @@ Maintainer: Evgeny Boger <boger@contactless.ru>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 10), pkg-config, libjsoncpp-dev, libwbmqtt1-dev (>= 1.1.0)
+Build-Depends: debhelper (>= 10), pkg-config, libwbmqtt1-2-dev (>= 2.2.2)
 
 Package: wb-mqtt-gpio
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libjsoncpp0 | libjsoncpp1, ucf, libwbmqtt1 (>= 1.1.0), wb-configs (>= 1.82.2)
+Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, libwbmqtt1-2 (>= 2.2.2), wb-configs (>= 1.82.2)
 Breaks: wb-mqtt-confed (<< 1.0.2), wb-homa-gpio (<< 2.0.1)
 Replaces: wb-homa-gpio (<< 2.0.1)
 Conflicts: wb-homa-gpio (<< 2.0.1)

--- a/gpio_driver.cpp
+++ b/gpio_driver.cpp
@@ -158,6 +158,9 @@ TGpioDriver::TGpioDriver(const WBMQTT::PDeviceDriver & mqttDriver, const TGpioDr
         const auto & line = event.Control->GetUserData().As<PGpioLine>();
         if (line->IsOutput()) {
             line->SetValue(value);
+            event.Control->GetDevice()->GetDriver()->AccessAsync([=](const PDriverTx & tx){
+                event.Control->SetRawValue(tx, event.RawValue);
+            });
         } else {
             LOG(Warn) << "Attempt to write value to input " << line->DescribeShort();
         }


### PR DESCRIPTION
Rebase of https://github.com/wirenboard/wb-homa-gpio/pull/19

Port to new libwbmqtt1-2. libwbmqtt1-2 does not set topic value after receiving a message in "on" topic, so driver code must decide itself what to do.