### PR TITLE
"on" topic for total controls is added

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-gpio (2.4.0) unstable; urgency=medium
+
+  * Setting of counters total values by publishing in appropriate "on" topic is implemented
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Thu, 15 Jul 2021 10:28:24 +0500
+
 wb-mqtt-gpio (2.3.0) unstable; urgency=medium
 
   * libwbmqtt1-2 2.1.0 support

--- a/gpio_counter.h
+++ b/gpio_counter.h
@@ -4,6 +4,7 @@
 #include "types.h"
 
 #include <vector>
+#include <mutex>
 
 class TGpioCounter
 {
@@ -27,6 +28,7 @@ class TGpioCounter
     EGpioEdge       InterruptEdge;
     TTimeIntervalUs PreviousInterval;
 
+    mutable std::mutex AccessMutex;
 public:
     explicit TGpioCounter(const TGpioLineConfig & config);
     ~TGpioCounter();
@@ -40,12 +42,17 @@ public:
     uint64_t GetCounts() const;
     std::vector<TMetadataPair> GetIdsAndTypes(const std::string & baseId) const;
     std::vector<TValuePair>    GetIdsAndValues(const std::string & baseId) const;
+    std::string                GetRoundedTotal() const;
 
     void SetInterruptEdge(EGpioEdge);
     EGpioEdge GetInterruptEdge() const;
 
-    void SetInitialValues(float total); // set total when starting
-
+    /**
+     * @brief Sets total value. Counts value is set to zero. Thread safe.
+     * 
+     * @param total new total value
+     */
+    void SetInitialValues(float total);
 private:
     void UpdateCurrent(const TTimeIntervalUs &);
     void UpdateTotal();


### PR DESCRIPTION
Rebase of https://github.com/wirenboard/wb-homa-gpio/pull/20

* Попавил публикацию значения после получения сообщения в "on" топике
* Теперь HA вообще не будет работать, т.к изменения выхода полько на `0` и `1`. Точнее оно и раньше не работало, но теперь не будет вводить в заблуждение.